### PR TITLE
Add task check strategies

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,13 +1,8 @@
 name: run-tests
 
 on:
+  pull_request:
   push:
-    paths:
-      - '**.php'
-      - '.github/workflows/run-tests.yml'
-      - 'phpunit.xml.dist'
-      - 'composer.json'
-      - 'composer.lock'
 
 jobs:
   test:

--- a/config/long-running-tasks.php
+++ b/config/long-running-tasks.php
@@ -14,6 +14,19 @@ return [
     'default_check_frequency_in_seconds' => 10,
 
     /*
+     * The default class that implements a strategy for determining the check frequency in seconds.
+     * - `DefaultCheckStrategy` will check the task every `LongRunningTaskLogItem::check_frequency_in_seconds` seconds.
+     * - `StandardBackoffCheckStrategy` will check the task every `LongRunningTaskLogItem::check_frequency_in_seconds` seconds,
+     *    but will increase the frequency with the multipliers 1, 6, 12, 30, 60, with the maximum being 60 times the original frequency.
+     *    With the default check frequency, this translates to 10, 60, 120, 300, and 600 seconds between checks.
+     * - `LinearBackoffCheckStrategy` will check the task every `LongRunningTaskLogItem::check_frequency_in_seconds` seconds,
+     *   but will increase the frequency linearly with each attempt, up to a maximum multiple of 6 times the original frequency.
+     * - `ExponentialBackoffCheckStrategy` will check the task every `LongRunningTaskLogItem::check_frequency_in_seconds` seconds,
+     *   but will increase the frequency exponentially with each attempt, up to a maximum of 6 times the original frequency.
+     */
+    'default_check_strategy_class' => Spatie\LongRunningTasks\Strategies\DefaultCheckStrategy::class,
+
+    /*
      * When a task is not completed in this amount of time,
      * it will not run again, and marked as `didNotComplete`.
      */

--- a/src/Exceptions/InvalidStrategyClass.php
+++ b/src/Exceptions/InvalidStrategyClass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\LongRunningTasks\Exceptions;
+
+use Exception;
+
+class InvalidStrategyClass extends Exception
+{
+    public static function classDoesNotExist(string $class): self
+    {
+        return new static("Class `{$class}` does not exist.");
+    }
+
+    public static function classIsNotAStrategy(string $class): self
+    {
+        return new static("Class `{$class}` is not a strategy.");
+    }
+}

--- a/src/Jobs/RunLongRunningTaskJob.php
+++ b/src/Jobs/RunLongRunningTaskJob.php
@@ -98,7 +98,8 @@ class RunLongRunningTaskJob implements ShouldBeUniqueUntilProcessing, ShouldQueu
 
         $job = new static($this->longRunningTaskLogItem);
 
-        $delay = $this->longRunningTaskLogItem->check_frequency_in_seconds;
+        $task = $this->longRunningTaskLogItem->task();
+        $delay = $task->getCheckStrategy()->checkFrequencyInSeconds($this->longRunningTaskLogItem);
 
         $queue = $this->longRunningTaskLogItem->queue;
 

--- a/src/Strategies/CheckStrategy.php
+++ b/src/Strategies/CheckStrategy.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\LongRunningTasks\Strategies;
+
+use Spatie\LongRunningTasks\Models\LongRunningTaskLogItem;
+
+interface CheckStrategy
+{
+    public function checkFrequencyInSeconds(LongRunningTaskLogItem $logItem): int;
+}

--- a/src/Strategies/DefaultCheckStrategy.php
+++ b/src/Strategies/DefaultCheckStrategy.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\LongRunningTasks\Strategies;
+
+use Spatie\LongRunningTasks\Models\LongRunningTaskLogItem;
+
+class DefaultCheckStrategy implements CheckStrategy
+{
+    public function checkFrequencyInSeconds(LongRunningTaskLogItem $logItem): int
+    {
+        return $logItem->check_frequency_in_seconds;
+    }
+}

--- a/src/Strategies/ExponentialBackoffCheckStrategy.php
+++ b/src/Strategies/ExponentialBackoffCheckStrategy.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\LongRunningTasks\Strategies;
+
+use Spatie\LongRunningTasks\Models\LongRunningTaskLogItem;
+
+class ExponentialBackoffCheckStrategy implements CheckStrategy
+{
+    public function checkFrequencyInSeconds(LongRunningTaskLogItem $logItem): int
+    {
+        if ($logItem->attempt === 1) {
+            return $logItem->check_frequency_in_seconds;
+        }
+
+        return ($logItem->check_frequency_in_seconds * 0.5) ** min($logItem->attempt, 4);
+    }
+}

--- a/src/Strategies/LinearBackoffCheckStrategy.php
+++ b/src/Strategies/LinearBackoffCheckStrategy.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\LongRunningTasks\Strategies;
+
+use Spatie\LongRunningTasks\Models\LongRunningTaskLogItem;
+
+class LinearBackoffCheckStrategy implements CheckStrategy
+{
+    public function checkFrequencyInSeconds(LongRunningTaskLogItem $logItem): int
+    {
+        return $logItem->check_frequency_in_seconds * min([$logItem->attempt, 6]);
+    }
+}

--- a/src/Strategies/StandardBackoffCheckStrategy.php
+++ b/src/Strategies/StandardBackoffCheckStrategy.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spatie\LongRunningTasks\Strategies;
+
+use Spatie\LongRunningTasks\Models\LongRunningTaskLogItem;
+
+class StandardBackoffCheckStrategy implements CheckStrategy
+{
+    public function frequencies(LongRunningTaskLogItem $logItem): array
+    {
+        $frequency = $logItem->check_frequency_in_seconds;
+
+        return [
+            $frequency,
+            $frequency * 6,
+            $frequency * 12,
+            $frequency * 30,
+            $frequency * 60,
+        ];
+
+    }
+
+    public function checkFrequencyInSeconds(LongRunningTaskLogItem $logItem): int
+    {
+        $frequencies = $this->frequencies($logItem);
+
+        return $logItem->attempt >= count($frequencies)
+            ? $frequencies[count($frequencies) - 1]
+            : $frequencies[($logItem->attempt % count($frequencies)) - 1];
+    }
+
+}

--- a/tests/Strategies/CheckStrategyTest.php
+++ b/tests/Strategies/CheckStrategyTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use Spatie\LongRunningTasks\Strategies\LinearBackoffCheckStrategy;
+use Spatie\LongRunningTasks\Strategies\ExponentialBackoffCheckStrategy;
+use Spatie\LongRunningTasks\Models\LongRunningTaskLogItem;
+
+it('implements a linear backoff strategy', function () {
+    $strategy = new LinearBackoffCheckStrategy();
+
+    $logItem = LongRunningTaskLogItem::factory()->create();
+
+    $logItem->check_frequency_in_seconds = 10;
+    $logItem->attempt = 1;
+
+    expect($strategy->checkFrequencyInSeconds($logItem))->toBe(10);
+
+    $logItem->attempt = 2;
+    expect($strategy->checkFrequencyInSeconds($logItem))->toBe(20);
+
+    $logItem->attempt = 3;
+    expect($strategy->checkFrequencyInSeconds($logItem))->toBe(30);
+
+    $logItem->attempt = 4;
+    expect($strategy->checkFrequencyInSeconds($logItem))->toBe(40);
+
+    $logItem->attempt = 5;
+    expect($strategy->checkFrequencyInSeconds($logItem))->toBe(50);
+
+    $logItem->attempt = 6;
+    expect($strategy->checkFrequencyInSeconds($logItem))->toBe(60);
+
+    $logItem->attempt = 7;
+    expect($strategy->checkFrequencyInSeconds($logItem))->toBe(60);
+});
+
+it('implements an exponential backoff strategy', function () {
+    $strategy = new ExponentialBackoffCheckStrategy();
+
+    $logItem = LongRunningTaskLogItem::factory()->create();
+
+    $logItem->check_frequency_in_seconds = 10;
+    $logItem->attempt = 1;
+
+    expect($strategy->checkFrequencyInSeconds($logItem))->toBe(10);
+
+    $logItem->attempt = 2;
+    expect($strategy->checkFrequencyInSeconds($logItem))->toBe(25);
+
+    $logItem->attempt = 3;
+    expect($strategy->checkFrequencyInSeconds($logItem))->toBe(125);
+
+    $logItem->attempt = 4;
+    expect($strategy->checkFrequencyInSeconds($logItem))->toBe(625);
+
+    $logItem->attempt = 5;
+    expect($strategy->checkFrequencyInSeconds($logItem))->toBe(625);
+
+    $logItem->attempt = 6;
+    expect($strategy->checkFrequencyInSeconds($logItem))->toBe(625);
+});
+
+it('implements a standard backoff strategy', function () {
+    $strategy = new Spatie\LongRunningTasks\Strategies\StandardBackoffCheckStrategy();
+
+    $logItem = LongRunningTaskLogItem::factory()->create();
+
+    $logItem->check_frequency_in_seconds = 10;
+    $logItem->attempt = 1;
+
+    expect($strategy->checkFrequencyInSeconds($logItem))->toBe(10);
+
+    $logItem->attempt = 2;
+    expect($strategy->checkFrequencyInSeconds($logItem))->toBe(60);
+
+    $logItem->attempt = 3;
+    expect($strategy->checkFrequencyInSeconds($logItem))->toBe(120);
+
+    $logItem->attempt = 4;
+    expect($strategy->checkFrequencyInSeconds($logItem))->toBe(300);
+
+    $logItem->attempt = 5;
+    expect($strategy->checkFrequencyInSeconds($logItem))->toBe(600);
+
+    $logItem->attempt = 6;
+    expect($strategy->checkFrequencyInSeconds($logItem))->toBe(600);
+});


### PR DESCRIPTION
This PR adds "check strategies" to the `LongRunningTask` class.  Check Strategies allow for customization of the check frequency via one of the provided or custom class that implements the `CheckStrategy` contract.  Instead of directly using the `check_frequency_in_seconds` attribute, the strategy for the Task is used to calculate the frequency.

The following strategies are provided, with the default being `DefaultCheckStrategy`:

 - `DefaultCheckStrategy` will check the task every `LongRunningTaskLogItem::check_frequency_in_seconds` seconds.
 - `StandardBackoffCheckStrategy` will check the task every `LongRunningTaskLogItem::check_frequency_in_seconds` seconds, but will increase the frequency with the multipliers 1, 6, 12, 30, 60, with the maximum being 60 times the original frequency. With the default check frequency, this translates to 10, 60, 120, 300, and 600 seconds between checks.
 - `LinearBackoffCheckStrategy` will check the task every `LongRunningTaskLogItem::check_frequency_in_seconds` seconds, but will increase the frequency linearly with each attempt, up to a maximum multiple of 6 times the original frequency.
 - `ExponentialBackoffCheckStrategy` will check the task every `LongRunningTaskLogItem::check_frequency_in_seconds` seconds, but will increase the frequency exponentially with each attempt, up to a maximum of 6 times the original frequency.

Although semver allows for breaking changes for version zero releases, there are no breaking changes in this PR. To upgrade from `v0.0.3`, the `default_check_strategy_class` configuration item should be added, but defaults to `DefaultCheckStrategy` if it does not exist.