### PR TITLE
Add Laravel 13 support and upgrade to Pest 4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.4, 8.3, 8.2]
-        laravel: [10.*, 11.*, 12.*]
+        php: [8.5, 8.4, 8.3]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-stable]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
         "orchestra/testbench": "^9.0|^10.0|^11.0",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-arch": "^4.0",
-        "pestphp/pest-plugin-laravel": "^4.0",
-        "spatie/laravel-ray": "^1.26"
+        "pestphp/pest-plugin-laravel": "^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,18 +15,18 @@
         }
     ],
     "require": {
-        "php": "^8.2",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "php": "^8.3",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.20.1",
         "spatie/test-time": "^1.3.3"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.0|^8.1",
-        "orchestra/testbench": "^8.8|^9.0|^10.0",
-        "pestphp/pest": "^2.20|^3.0",
-        "pestphp/pest-plugin-arch": "^2.5|^3.0",
-        "pestphp/pest-plugin-laravel": "^2.0|^3.0",
+        "nunomaduro/collision": "^8.1",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^4.0",
+        "pestphp/pest-plugin-arch": "^4.0",
+        "pestphp/pest-plugin-laravel": "^4.0",
         "spatie/laravel-ray": "^1.26"
     },
     "autoload": {

--- a/config/long-running-tasks.php
+++ b/config/long-running-tasks.php
@@ -1,5 +1,9 @@
 <?php
 
+use Spatie\LongRunningTasks\Jobs\RunLongRunningTaskJob;
+use Spatie\LongRunningTasks\Models\LongRunningTaskLogItem;
+use Spatie\LongRunningTasks\Strategies\DefaultCheckStrategy;
+
 return [
     /*
      * Behind the scenes, this packages use a queue to call tasks.
@@ -24,7 +28,7 @@ return [
      * - `ExponentialBackoffCheckStrategy` will check the task every `LongRunningTaskLogItem::check_frequency_in_seconds` seconds,
      *   but will increase the frequency exponentially with each attempt, up to a maximum of 6 times the original frequency.
      */
-    'default_check_strategy_class' => Spatie\LongRunningTasks\Strategies\DefaultCheckStrategy::class,
+    'default_check_strategy_class' => DefaultCheckStrategy::class,
 
     /*
      * When a task is not completed in this amount of time,
@@ -36,10 +40,10 @@ return [
      * The model that will be used by default to track
      * the status of all tasks.
      */
-    'log_model' => Spatie\LongRunningTasks\Models\LongRunningTaskLogItem::class,
+    'log_model' => LongRunningTaskLogItem::class,
 
     /*
      * The job responsible for calling tasks.
      */
-    'task_job' => Spatie\LongRunningTasks\Jobs\RunLongRunningTaskJob::class,
+    'task_job' => RunLongRunningTaskJob::class,
 ];

--- a/tests/LongRunningTaskTest.php
+++ b/tests/LongRunningTaskTest.php
@@ -75,7 +75,7 @@ it('will can handle a task that always fails', function () {
     $task->start();
 
     expect(LongRunningTaskLogItem::first())
-        ->status->toBe(LogitemStatus::Failed)
+        ->status->toBe(LogItemStatus::Failed)
         ->run_count->toBe(1)
         ->latest_exception->toHaveKeys(['message', 'trace']);
 });
@@ -101,7 +101,7 @@ it('can handle a task that will recover', function () {
     $task->start();
 
     expect(LongRunningTaskLogItem::first())
-        ->status->toBe(LogitemStatus::Completed)
+        ->status->toBe(LogItemStatus::Completed)
         ->run_count->toBe(3)
         ->latest_exception->toBeNull();
 });
@@ -120,7 +120,7 @@ it('will stop a task that would run forever', function () {
     $task->start();
 
     expect(LongRunningTaskLogItem::first())
-        ->status->toBe(LogitemStatus::DidNotComplete)
+        ->status->toBe(LogItemStatus::DidNotComplete)
         ->run_count->toBeGreaterThan(1);
 });
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,6 +2,4 @@
 
 use Spatie\LongRunningTasks\Tests\TestCase;
 
-uses(TestCase::class)
-    ->beforeEach(fn () => ray()->newScreen($this->name()))
-    ->in(__DIR__);
+uses(TestCase::class)->in(__DIR__);

--- a/tests/Strategies/CheckStrategyTest.php
+++ b/tests/Strategies/CheckStrategyTest.php
@@ -3,6 +3,7 @@
 use Spatie\LongRunningTasks\Models\LongRunningTaskLogItem;
 use Spatie\LongRunningTasks\Strategies\ExponentialBackoffCheckStrategy;
 use Spatie\LongRunningTasks\Strategies\LinearBackoffCheckStrategy;
+use Spatie\LongRunningTasks\Strategies\StandardBackoffCheckStrategy;
 
 it('implements a linear backoff strategy', function () {
     $strategy = new LinearBackoffCheckStrategy;
@@ -60,7 +61,7 @@ it('implements an exponential backoff strategy', function () {
 });
 
 it('implements a standard backoff strategy', function () {
-    $strategy = new Spatie\LongRunningTasks\Strategies\StandardBackoffCheckStrategy;
+    $strategy = new StandardBackoffCheckStrategy;
 
     $logItem = LongRunningTaskLogItem::factory()->create();
 


### PR DESCRIPTION
## Summary

- Add Laravel 13 to the support matrix (`illuminate/contracts: ^11.0|^12.0|^13.0`).
- Upgrade testing stack to Pest 4 (which requires PHP 8.3+).
- Drop support for Laravel 10 and PHP 8.2 (not compatible with Pest 4).
- Update CI matrix to PHP 8.3/8.4/8.5 against Laravel 11/12/13.

Resolves the question raised in discussion #22.